### PR TITLE
Add term meta for post series introduction page

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+tab_width = 4
+indent_style = tab
+insert_final_newline = false
+trim_trailing_whitespace = true
+
+[*.txt]
+trim_trailing_whitespace = false
+
+[*.{md,json,yml}]
+trim_trailing_whitespace = false
+indent_style = space
+indent_size = 2

--- a/src/Admin/Post.php
+++ b/src/Admin/Post.php
@@ -3,6 +3,7 @@
 namespace DeliciousBrains\WPPostSeries\Admin;
 
 use DeliciousBrains\WPPostSeries\Post as FrontPost;
+use DeliciousBrains\WPPostSeries\PostSeries;
 
 class Post {
 
@@ -61,7 +62,7 @@ class Post {
 			if ( $current_series ) {
 				echo '<a href="' . esc_url( admin_url( 'edit.php?post_series=' . $current_series->slug ) ) . '">' . esc_html( $current_series->name ) . '</a>';
 			} else {
-				_e( 'N/A', 'delicious_brains' );
+				_e( 'N/A', PostSeries::TEXT_DOMAIN );
 			}
 		}
 	}
@@ -84,7 +85,7 @@ class Post {
 		}
 		?>
 		<select name="post_series">
-			<option value=""><?php _e( 'Show all series', 'delicious_brains' ) ?></option>
+			<option value=""><?php _e( 'Show all series', PostSeries::TEXT_DOMAIN ) ?></option>
 			<?php foreach ( $all_series as $series ) : ?>
 				<option value="<?php echo esc_attr( $series->slug ); ?>" <?php selected( $current_series, $series->slug ); ?>><?php echo esc_html( $series->name ); ?></option>
 			<?php endforeach; ?>

--- a/src/Admin/Post.php
+++ b/src/Admin/Post.php
@@ -41,7 +41,7 @@ class Post {
 			$new_columns[ $key ] = $column;
 
 			if ( 'categories' == $key ) {
-				$new_columns["post_series"] = __( "Series", "wp_post_series" );
+				$new_columns["post_series"] = __( "Series", PostSeries::TEXT_DOMAIN );
 			}
 		}
 
@@ -78,7 +78,7 @@ class Post {
 		}
 
 		$current_series = isset( $_REQUEST['post_series'] ) ? sanitize_text_field( $_REQUEST['post_series'] ) : '';
-		$all_series     = get_terms( 'post_series', array( 'hide_empty' => true, 'orderby' => 'name' ) );
+		$all_series     = get_terms( PostSeries::TAXONOMY_NAME, array( 'hide_empty' => true, 'orderby' => 'name' ) );
 
 		if ( empty( $all_series ) ) {
 			return;
@@ -103,8 +103,8 @@ class Post {
 		$current_series = $this->post->get_post_series_id( $post->ID );
 
 		// Get list of all series and the taxonomy
-		$tax        = get_taxonomy( 'post_series' );
-		$all_series = get_terms( 'post_series', array( 'hide_empty' => false, 'orderby' => 'name' ) );
+		$tax        = get_taxonomy( PostSeries::TAXONOMY_NAME );
+		$all_series = get_terms( PostSeries::TAXONOMY_NAME, array( 'hide_empty' => false, 'orderby' => 'name' ) );
 
 		?>
 		<div id="taxonomy-<?php echo $tax->name; ?>" class="categorydiv">

--- a/src/Admin/Post.php
+++ b/src/Admin/Post.php
@@ -20,28 +20,28 @@ class Post {
 	}
 
 	public function init() {
-		add_filter( 'manage_edit-post_columns', array( $this, 'columns' ) );
-		add_action( 'manage_post_posts_custom_column', array( $this, 'custom_columns' ), 2 );
-		add_action( 'restrict_manage_posts', array( $this, 'posts_in_series' ) );
+		add_filter( 'manage_edit-post_columns', [ $this, 'columns' ] );
+		add_action( 'manage_post_posts_custom_column', [ $this, 'custom_columns' ], 2 );
+		add_action( 'restrict_manage_posts', [ $this, 'posts_in_series' ] );
 	}
 
 	/**
 	 * Output admin column headers
 	 *
-	 * @param  array $columns existing columns
+	 * @param array $columns existing columns
 	 *
 	 * @return array new columns
 	 */
 	public function columns( $columns ) {
 		if ( ! is_array( $columns ) ) {
-			$new_columns = array();
+			$new_columns = [];
 		}
 
 		foreach ( $columns as $key => $column ) {
 			$new_columns[ $key ] = $column;
 
 			if ( 'categories' == $key ) {
-				$new_columns["post_series"] = __( "Series", PostSeries::TEXT_DOMAIN );
+				$new_columns[ "post_series" ] = __( "Series", PostSeries::TEXT_DOMAIN );
 			}
 		}
 
@@ -51,7 +51,7 @@ class Post {
 	/**
 	 * Output admin column values
 	 *
-	 * @param  string $column key for the column
+	 * @param string $column key for the column
 	 */
 	public function custom_columns( $column ) {
 		global $post;
@@ -77,17 +77,20 @@ class Post {
 			return;
 		}
 
-		$current_series = isset( $_REQUEST['post_series'] ) ? sanitize_text_field( $_REQUEST['post_series'] ) : '';
-		$all_series     = get_terms( PostSeries::TAXONOMY_NAME, array( 'hide_empty' => true, 'orderby' => 'name' ) );
+		$current_series = isset( $_REQUEST[ 'post_series' ] ) ? sanitize_text_field( $_REQUEST[ 'post_series' ] ) : '';
+		$all_series = get_terms( PostSeries::TAXONOMY_NAME, [ 'hide_empty' => true, 'orderby' => 'name' ] );
 
 		if ( empty( $all_series ) ) {
 			return;
 		}
 		?>
-		<select name="post_series">
-			<option value=""><?php _e( 'Show all series', PostSeries::TEXT_DOMAIN ) ?></option>
+		<select
+			name="post_series">
+			<option
+				value=""><?php _e( 'Show all series', PostSeries::TEXT_DOMAIN ) ?></option>
 			<?php foreach ( $all_series as $series ) : ?>
-				<option value="<?php echo esc_attr( $series->slug ); ?>" <?php selected( $current_series, $series->slug ); ?>><?php echo esc_html( $series->name ); ?></option>
+				<option
+					value="<?php echo esc_attr( $series->slug ); ?>" <?php selected( $current_series, $series->slug ); ?>><?php echo esc_html( $series->name ); ?></option>
 			<?php endforeach; ?>
 		</select>
 		<?php
@@ -96,25 +99,33 @@ class Post {
 	/**
 	 * Output the list of post series and allow admin to assign to a post. Uses a select box.
 	 *
-	 * @param  array $post Post being edited
+	 * @param array $post Post being edited
 	 */
 	public function post_series_meta_box( $post ) {
 		// Get the current series for the post if set
 		$current_series = $this->post->get_post_series_id( $post->ID );
 
 		// Get list of all series and the taxonomy
-		$tax        = get_taxonomy( PostSeries::TAXONOMY_NAME );
-		$all_series = get_terms( PostSeries::TAXONOMY_NAME, array( 'hide_empty' => false, 'orderby' => 'name' ) );
+		$tax = get_taxonomy( PostSeries::TAXONOMY_NAME );
+		$all_series = get_terms( PostSeries::TAXONOMY_NAME, [ 'hide_empty' => false, 'orderby' => 'name' ] );
 
 		?>
-		<div id="taxonomy-<?php echo $tax->name; ?>" class="categorydiv">
-			<label class="screen-reader-text" for="new_post_series_parent">
+		<div
+			id="taxonomy-<?php echo $tax->name; ?>"
+			class="categorydiv">
+			<label
+				class="screen-reader-text"
+				for="new_post_series_parent">
 				<?php echo $tax->labels->parent_item_colon; ?>
 			</label>
-			<select name="tax_input[post_series]" style="width:100%">
-				<option value="0"><?php echo '&mdash; ' . $tax->labels->parent_item . ' &mdash;'; ?></option>
+			<select
+				name="tax_input[post_series]"
+				style="width:100%">
+				<option
+					value="0"><?php echo '&mdash; ' . $tax->labels->parent_item . ' &mdash;'; ?></option>
 				<?php foreach ( $all_series as $series ) : ?>
-					<option value="<?php echo esc_attr( $series->slug ); ?>" <?php selected( $current_series, $series->term_id ); ?>><?php echo esc_html( $series->name ); ?></option>
+					<option
+						value="<?php echo esc_attr( $series->slug ); ?>" <?php selected( $current_series, $series->term_id ); ?>><?php echo esc_html( $series->name ); ?></option>
 				<?php endforeach; ?>
 			</select>
 		</div>

--- a/src/Admin/PostSeriesMeta.php
+++ b/src/Admin/PostSeriesMeta.php
@@ -28,7 +28,7 @@ class PostSeriesMeta {
 	 * @return void
 	 */
 	public function output_create_fields( $taxonomy ) {
-		$this->edit_fields( null, $taxonomy );
+		$this->output_edit_fields( null, $taxonomy );
 	}
 
 	/**

--- a/src/Admin/PostSeriesMeta.php
+++ b/src/Admin/PostSeriesMeta.php
@@ -9,78 +9,82 @@ use DeliciousBrains\WPPostSeries\PostSeries;
  */
 class PostSeriesMeta {
 
-    const INTRO_PAGE_ID_META_KEY = '_post_series_intro_page_id';
-    const INTRO_PAGE_ID_FIELD_NAME = 'introduction';
+	const INTRO_PAGE_ID_META_KEY = '_post_series_intro_page_id';
+	const INTRO_PAGE_ID_FIELD_NAME = 'introduction';
 
-    public function __construct() {
-        if ( is_admin() ) {
-            add_action( 'post_series_add_form_fields', [ $this, 'output_create_fields' ], 50, 2 );
-            add_action( 'post_series_edit_form_fields', [ $this, 'output_edit_fields' ], 50, 2 );
-            add_action( 'created_post_series', [ $this, 'save_fields' ], 10, 1 );
-            add_action( 'edited_post_series', [ $this, 'save_fields' ], 10, 1 );
-        }
-    }
+	public function __construct() {
+		if ( is_admin() ) {
+			add_action( 'post_series_add_form_fields', [ $this, 'output_create_fields' ], 50, 2 );
+			add_action( 'post_series_edit_form_fields', [ $this, 'output_edit_fields' ], 50, 2 );
+			add_action( 'created_post_series', [ $this, 'save_fields' ], 10, 1 );
+			add_action( 'edited_post_series', [ $this, 'save_fields' ], 10, 1 );
+		}
+	}
 
-    /**
-     * Show fields for creating a new term in the post series taxonomy.
-     *
-     * @param string $taxonomy  The taxonomy we are showing create fields for
-     * @return void
-     */
-    public function output_create_fields( $taxonomy ) {
-        $this->edit_fields( null, $taxonomy );
-    }
+	/**
+	 * Show fields for creating a new term in the post series taxonomy.
+	 *
+	 * @param string $taxonomy The taxonomy we are showing create fields for
+	 * @return void
+	 */
+	public function output_create_fields( $taxonomy ) {
+		$this->edit_fields( null, $taxonomy );
+	}
 
-    /**
-     * Show fields for editing an existing term in the post series taxonomy.
-     *
-     * @param \WP_Term|null $post_series The post series term we are showing edit fields for
-     * @param string        $taxonomy    The taxonomy that the term is from
-     * @return void
-     */
-    public function output_edit_fields( $post_series, $taxonomy ) {
-        $intro_page_id = ! is_null( $post_series ) ? PostSeries::get_intro_page_id( $post_series ) : null;
-        ?>
-        <table class="form-table"
-               role="presentation">
-            <tbody>
-            <tr class="form-field">
-                <th scope="row">
-                    <label for="<?php echo self::INTRO_PAGE_ID_FIELD_NAME ?>">
-                        <?php _e( 'Introduction post', PostSeries::TEXT_DOMAIN ) ?>
-                    </label>
-                </th>
-                <td>
-                    <select name="<?php echo self::INTRO_PAGE_ID_FIELD_NAME ?>"
-                            id="<?php echo self::INTRO_PAGE_ID_FIELD_NAME ?>">
+	/**
+	 * Show fields for editing an existing term in the post series taxonomy.
+	 *
+	 * @param \WP_Term|null $post_series The post series term we are showing edit fields for
+	 * @param string $taxonomy The taxonomy that the term is from
+	 * @return void
+	 */
+	public function output_edit_fields( $post_series, $taxonomy ) {
+		$intro_page_id = ! is_null( $post_series ) ? PostSeries::get_intro_page_id( $post_series ) : null;
+		?>
+		<table
+			class="form-table"
+			role="presentation">
+			<tbody>
+			<tr class="form-field">
+				<th scope="row">
+					<label
+						for="<?php echo self::INTRO_PAGE_ID_FIELD_NAME ?>">
+						<?php _e( 'Introduction post', PostSeries::TEXT_DOMAIN ) ?>
+					</label>
+				</th>
+				<td>
+					<select
+						name="<?php echo self::INTRO_PAGE_ID_FIELD_NAME ?>"
+						id="<?php echo self::INTRO_PAGE_ID_FIELD_NAME ?>">
 
-                        <?php foreach ( get_pages() as $page ) : ?>
-                            <option value="<?php echo esc_attr( $page->ID ) ?>" <?php selected( $page->ID, $intro_page_id ) ?>>
-                                <?php echo esc_html( get_the_title( $page ) ); ?>
-                            </option>
-                        <?php endforeach; ?>
-                    </select>
-                    <p class="description">
-                        <?php _e( 'Choose a page to use as the introduction page for the post series.', PostSeries::TEXT_DOMAIN ); ?>
-                    </p>
-                </td>
-            </tr>
-            </tbody>
-        </table>
-        <?php
-    }
+						<?php foreach ( get_pages() as $page ) : ?>
+							<option
+								value="<?php echo esc_attr( $page->ID ) ?>" <?php selected( $page->ID, $intro_page_id ) ?>>
+								<?php echo esc_html( get_the_title( $page ) ); ?>
+							</option>
+						<?php endforeach; ?>
+					</select>
+					<p class="description">
+						<?php _e( 'Choose a page to use as the introduction page for the post series.', PostSeries::TEXT_DOMAIN ); ?>
+					</p>
+				</td>
+			</tr>
+			</tbody>
+		</table>
+		<?php
+	}
 
-    /**
-     * Save the custom meta fields for post series terms
-     *
-     * @param int $term_id  The ID of the term being saved
-     * @return void
-     */
-    public function save_fields( $term_id ) {
-        if ( isset( $_POST[ self::INTRO_PAGE_ID_FIELD_NAME ] ) ) {
-            $sanitized_id = filter_input( INPUT_POST, self::INTRO_PAGE_ID_FIELD_NAME, FILTER_VALIDATE_INT );
-            PostSeries::set_intro_page_id( $term_id, $sanitized_id );
-        }
-    }
+	/**
+	 * Save the custom meta fields for post series terms
+	 *
+	 * @param int $term_id The ID of the term being saved
+	 * @return void
+	 */
+	public function save_fields( $term_id ) {
+		if ( isset( $_POST[ self::INTRO_PAGE_ID_FIELD_NAME ] ) ) {
+			$sanitized_id = filter_input( INPUT_POST, self::INTRO_PAGE_ID_FIELD_NAME, FILTER_VALIDATE_INT );
+			PostSeries::set_intro_page_id( $term_id, $sanitized_id );
+		}
+	}
 }
 

--- a/src/Admin/PostSeriesMeta.php
+++ b/src/Admin/PostSeriesMeta.php
@@ -57,6 +57,10 @@ class PostSeriesMeta {
 						name="<?php echo self::INTRO_PAGE_ID_FIELD_NAME ?>"
 						id="<?php echo self::INTRO_PAGE_ID_FIELD_NAME ?>">
 
+						<option value="">
+							No introduction page
+						</option>
+
 						<?php foreach ( get_pages() as $page ) : ?>
 							<option
 								value="<?php echo esc_attr( $page->ID ) ?>" <?php selected( $page->ID, $intro_page_id ) ?>>

--- a/src/Admin/PostSeriesMeta.php
+++ b/src/Admin/PostSeriesMeta.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace DeliciousBrains\WPPostSeries\Admin;
+
+use DeliciousBrains\WPPostSeries\PostSeries;
+
+/**
+ * Class to add term meta fields to the post series taxonomy
+ */
+class PostSeriesMeta {
+
+    const INTRO_PAGE_ID_META_KEY = '_post_series_intro_page_id';
+    const INTRO_PAGE_ID_FIELD_NAME = 'introduction';
+
+    public function __construct() {
+        if ( is_admin() ) {
+            add_action( 'post_series_add_form_fields', [ $this, 'output_create_fields' ], 50, 2 );
+            add_action( 'post_series_edit_form_fields', [ $this, 'output_edit_fields' ], 50, 2 );
+            add_action( 'created_post_series', [ $this, 'save_fields' ], 10, 1 );
+            add_action( 'edited_post_series', [ $this, 'save_fields' ], 10, 1 );
+        }
+    }
+
+    /**
+     * Show fields for creating a new term in the post series taxonomy.
+     *
+     * @param string $taxonomy  The taxonomy we are showing create fields for
+     * @return void
+     */
+    public function output_create_fields( $taxonomy ) {
+        $this->edit_fields( null, $taxonomy );
+    }
+
+    /**
+     * Show fields for editing an existing term in the post series taxonomy.
+     *
+     * @param \WP_Term|null $post_series The post series term we are showing edit fields for
+     * @param string        $taxonomy    The taxonomy that the term is from
+     * @return void
+     */
+    public function output_edit_fields( $post_series, $taxonomy ) {
+        $intro_page_id = ! is_null( $post_series ) ? PostSeries::get_intro_page_id( $post_series ) : null;
+        ?>
+        <table class="form-table"
+               role="presentation">
+            <tbody>
+            <tr class="form-field">
+                <th scope="row">
+                    <label for="<?php echo self::INTRO_PAGE_ID_FIELD_NAME ?>">
+                        <?php _e( 'Introduction post', PostSeries::TEXT_DOMAIN ) ?>
+                    </label>
+                </th>
+                <td>
+                    <select name="<?php echo self::INTRO_PAGE_ID_FIELD_NAME ?>"
+                            id="<?php echo self::INTRO_PAGE_ID_FIELD_NAME ?>">
+
+                        <?php foreach ( get_pages() as $page ) : ?>
+                            <option value="<?php echo esc_attr( $page->ID ) ?>" <?php selected( $page->ID, $intro_page_id ) ?>>
+                                <?php echo esc_html( get_the_title( $page ) ); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                    <p class="description">
+                        <?php _e( 'Choose a page to use as the introduction page for the post series.', PostSeries::TEXT_DOMAIN ); ?>
+                    </p>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+        <?php
+    }
+
+    /**
+     * Save the custom meta fields for post series terms
+     *
+     * @param int $term_id  The ID of the term being saved
+     * @return void
+     */
+    public function save_fields( $term_id ) {
+        if ( isset( $_POST[ self::INTRO_PAGE_ID_FIELD_NAME ] ) ) {
+            $sanitized_id = filter_input( INPUT_POST, self::INTRO_PAGE_ID_FIELD_NAME, FILTER_VALIDATE_INT );
+            PostSeries::set_intro_page_id( $term_id, $sanitized_id );
+        }
+    }
+}
+

--- a/src/Admin/Taxonomy.php
+++ b/src/Admin/Taxonomy.php
@@ -21,18 +21,18 @@ class Taxonomy {
 	}
 
 	public function init() {
-		add_action( 'init', array( $this, 'register_taxonomies' ) );
-		add_action( 'init', array( $this, 'register_term_meta' ) );
+		add_action( 'init', [ $this, 'register_taxonomies' ] );
+		add_action( 'init', [ $this, 'register_term_meta' ] );
 	}
 
 	public function register_taxonomies() {
-		$plural   = __( 'Post series', PostSeries::TEXT_DOMAIN );
+		$plural = __( 'Post series', PostSeries::TEXT_DOMAIN );
 		$singular = __( 'Post series', PostSeries::TEXT_DOMAIN );
 
-		register_taxonomy( PostSeries::TAXONOMY_NAME, array( 'post' ), array(
+		register_taxonomy( PostSeries::TAXONOMY_NAME, [ 'post' ], [
 			'hierarchical' => false,
 			'label'        => $plural,
-			'labels'       => array(
+			'labels'       => [
 				'menu_name'         => __( 'Series', PostSeries::TEXT_DOMAIN ),
 				'name'              => $plural,
 				'singular_name'     => $singular,
@@ -44,19 +44,19 @@ class Taxonomy {
 				'update_item'       => sprintf( __( 'Update %s', PostSeries::TEXT_DOMAIN ), $singular ),
 				'add_new_item'      => sprintf( __( 'Add New %s', PostSeries::TEXT_DOMAIN ), $singular ),
 				'new_item_name'     => sprintf( __( 'New %s Name', PostSeries::TEXT_DOMAIN ), $singular ),
-			),
+			],
 			'show_ui'      => true,
 			'query_var'    => true,
 			'rewrite'      => apply_filters( 'wp_post_series_enable_archive', false ),
-			'meta_box_cb'  => array( $this->post, 'post_series_meta_box' ),
-		) );
+			'meta_box_cb'  => [ $this->post, 'post_series_meta_box' ],
+		] );
 	}
 
-    public function register_term_meta() {
-        register_term_meta( PostSeries::TAXONOMY_NAME, PostSeriesMeta::INTRO_PAGE_ID_META_KEY, [
-            'type' => 'integer',
-            'description' => __( 'The ID of the post series introduction page', PostSeries::TEXT_DOMAIN),
-            'single' => true,
-        ] );
-    }
+	public function register_term_meta() {
+		register_term_meta( PostSeries::TAXONOMY_NAME, PostSeriesMeta::INTRO_PAGE_ID_META_KEY, [
+			'type'        => 'integer',
+			'description' => __( 'The ID of the post series introduction page', PostSeries::TEXT_DOMAIN ),
+			'single'      => true,
+		] );
+	}
 }

--- a/src/Admin/Taxonomy.php
+++ b/src/Admin/Taxonomy.php
@@ -29,7 +29,7 @@ class Taxonomy {
 		$plural   = __( 'Post series', PostSeries::TEXT_DOMAIN );
 		$singular = __( 'Post series', PostSeries::TEXT_DOMAIN );
 
-		register_taxonomy( 'post_series', array( 'post' ), array(
+		register_taxonomy( PostSeries::TAXONOMY_NAME, array( 'post' ), array(
 			'hierarchical' => false,
 			'label'        => $plural,
 			'labels'       => array(
@@ -53,7 +53,7 @@ class Taxonomy {
 	}
 
     public function register_term_meta() {
-        register_term_meta( 'post_series', PostSeriesMeta::INTRO_PAGE_ID_META_KEY, [
+        register_term_meta( PostSeries::TAXONOMY_NAME, PostSeriesMeta::INTRO_PAGE_ID_META_KEY, [
             'type' => 'integer',
             'description' => __( 'The ID of the post series introduction page', PostSeries::TEXT_DOMAIN),
             'single' => true,

--- a/src/Admin/Taxonomy.php
+++ b/src/Admin/Taxonomy.php
@@ -2,6 +2,8 @@
 
 namespace DeliciousBrains\WPPostSeries\Admin;
 
+use DeliciousBrains\WPPostSeries\PostSeries;
+
 class Taxonomy {
 
 	/**
@@ -20,6 +22,7 @@ class Taxonomy {
 
 	public function init() {
 		add_action( 'init', array( $this, 'register_taxonomies' ) );
+		add_action( 'init', array( $this, 'register_term_meta' ) );
 	}
 
 	public function register_taxonomies() {
@@ -48,4 +51,12 @@ class Taxonomy {
 			'meta_box_cb'  => array( $this->post, 'post_series_meta_box' ),
 		) );
 	}
+
+    public function register_term_meta() {
+        register_term_meta( 'post_series', PostSeriesMeta::INTRO_PAGE_ID_META_KEY, [
+            'type' => 'integer',
+            'description' => __( 'The ID of the post series introduction page', PostSeries::TEXT_DOMAIN),
+            'single' => true,
+        ] );
+    }
 }

--- a/src/Admin/Taxonomy.php
+++ b/src/Admin/Taxonomy.php
@@ -26,24 +26,24 @@ class Taxonomy {
 	}
 
 	public function register_taxonomies() {
-		$plural   = __( 'Post series', 'delicious_brains' );
-		$singular = __( 'Post series', 'delicious_brains' );
+		$plural   = __( 'Post series', PostSeries::TEXT_DOMAIN );
+		$singular = __( 'Post series', PostSeries::TEXT_DOMAIN );
 
 		register_taxonomy( 'post_series', array( 'post' ), array(
 			'hierarchical' => false,
 			'label'        => $plural,
 			'labels'       => array(
-				'menu_name'         => __( 'Series', 'delicious_brains' ),
+				'menu_name'         => __( 'Series', PostSeries::TEXT_DOMAIN ),
 				'name'              => $plural,
 				'singular_name'     => $singular,
-				'search_items'      => sprintf( __( 'Search %s', 'delicious_brains' ), $plural ),
-				'all_items'         => sprintf( __( 'All %s', 'delicious_brains' ), $plural ),
-				'parent_item'       => sprintf( __( '%s', 'delicious_brains' ), $singular ),
-				'parent_item_colon' => sprintf( __( '%s:', 'delicious_brains' ), $singular ),
-				'edit_item'         => sprintf( __( 'Edit %s', 'delicious_brains' ), $singular ),
-				'update_item'       => sprintf( __( 'Update %s', 'delicious_brains' ), $singular ),
-				'add_new_item'      => sprintf( __( 'Add New %s', 'delicious_brains' ), $singular ),
-				'new_item_name'     => sprintf( __( 'New %s Name', 'delicious_brains' ), $singular ),
+				'search_items'      => sprintf( __( 'Search %s', PostSeries::TEXT_DOMAIN ), $plural ),
+				'all_items'         => sprintf( __( 'All %s', PostSeries::TEXT_DOMAIN ), $plural ),
+				'parent_item'       => sprintf( __( '%s', PostSeries::TEXT_DOMAIN ), $singular ),
+				'parent_item_colon' => sprintf( __( '%s:', PostSeries::TEXT_DOMAIN ), $singular ),
+				'edit_item'         => sprintf( __( 'Edit %s', PostSeries::TEXT_DOMAIN ), $singular ),
+				'update_item'       => sprintf( __( 'Update %s', PostSeries::TEXT_DOMAIN ), $singular ),
+				'add_new_item'      => sprintf( __( 'Add New %s', PostSeries::TEXT_DOMAIN ), $singular ),
+				'new_item_name'     => sprintf( __( 'New %s Name', PostSeries::TEXT_DOMAIN ), $singular ),
 			),
 			'show_ui'      => true,
 			'query_var'    => true,

--- a/src/Post.php
+++ b/src/Post.php
@@ -29,7 +29,7 @@ class Post {
 		}
 
 		// Create series info box
-		$term_description = term_description( $series->term_id, 'post_series' );
+		$term_description = term_description( $series->term_id, PostSeries::TAXONOMY_NAME );
 		$posts_in_series  = get_posts( array(
 			'post_type'      => 'post',
 			'posts_per_page' => - 1,
@@ -39,9 +39,9 @@ class Post {
 			'order'          => 'asc',
 			'tax_query'      => array(
 				array(
-					'taxonomy' => 'post_series',
-					'field'    => 'slug',
-					'terms'    => $series->slug,
+                    'taxonomy' => PostSeries::TAXONOMY_NAME,
+                    'field'    => 'slug',
+                    'terms'    => $series->slug,
 				),
 			),
 		) );
@@ -95,7 +95,7 @@ class Post {
 			<p class="post-series-name">
 				<?php
 				if ( apply_filters( 'wp_post_series_enable_archive', false ) ) {
-					$series_name = '<a href="' . get_term_link( $series->term_id, 'post_series' ) . '">' . esc_html( $series->name ) . '</a>';
+					$series_name = '<a href="' . get_term_link( $series->term_id, PostSeries::TAXONOMY_NAME ) . '">' . esc_html( $series->name ) . '</a>';
 				} else {
 					$series_name = esc_html( $series->name );
 				}
@@ -140,7 +140,7 @@ class Post {
 	 * @return object the term object
 	 */
 	public function get_post_series( $post_id ) {
-		$series = wp_get_post_terms( $post_id, 'post_series' );
+		$series = wp_get_post_terms( $post_id, PostSeries::TAXONOMY_NAME );
 
 		if ( ! is_wp_error( $series ) && ! empty( $series ) && is_array( $series ) ) {
 			$series = current( $series );

--- a/src/Post.php
+++ b/src/Post.php
@@ -99,7 +99,7 @@ class Post {
 				} else {
 					$series_name = esc_html( $series->name );
 				}
-				printf( __( 'This is article %d of %d in the series <em>&ldquo;%s&rdquo;</em>', 'delicious_brains' ), $post_in_series, sizeof( $posts_in_series ), $series_name );
+				printf( __( 'This is article %d of %d in the series <em>&ldquo;%s&rdquo;</em>', PostSeries::TEXT_DOMAIN ), $post_in_series, sizeof( $posts_in_series ), $series_name );
 				?>
 			</p>
 

--- a/src/Post.php
+++ b/src/Post.php
@@ -5,13 +5,13 @@ namespace DeliciousBrains\WPPostSeries;
 class Post {
 
 	public function init() {
-		add_filter( 'the_content', array( $this, 'add_series_to_content' ) );
+		add_filter( 'the_content', [ $this, 'add_series_to_content' ] );
 	}
 
 	/**
 	 * Append/Prepend the series info box to the post content
 	 *
-	 * @param  string $content Post content
+	 * @param string $content Post content
 	 *
 	 * @return string Ammended post content
 	 */
@@ -30,21 +30,21 @@ class Post {
 
 		// Create series info box
 		$term_description = term_description( $series->term_id, PostSeries::TAXONOMY_NAME );
-		$posts_in_series  = get_posts( array(
-			'post_type'      => 'post',
-			'posts_per_page' => - 1,
-			'fields'         => 'ids',
-			'no_found_rows'  => true,
-			'orderby'        => 'date',
-			'order'          => 'asc',
-			'tax_query'      => array(
-				array(
-                    'taxonomy' => PostSeries::TAXONOMY_NAME,
-                    'field'    => 'slug',
-                    'terms'    => $series->slug,
-				),
-			),
-		) );
+		$posts_in_series = get_posts( [
+										  'post_type'      => 'post',
+										  'posts_per_page' => -1,
+										  'fields'         => 'ids',
+										  'no_found_rows'  => true,
+										  'orderby'        => 'date',
+										  'order'          => 'asc',
+										  'tax_query'      => [
+											  [
+												  'taxonomy' => PostSeries::TAXONOMY_NAME,
+												  'field'    => 'slug',
+												  'terms'    => $series->slug,
+											  ],
+										  ],
+									  ] );
 
 		$post_in_series = 1;
 
@@ -52,7 +52,7 @@ class Post {
 			if ( $post_id == $post->ID ) {
 				break;
 			}
-			$post_in_series ++;
+			$post_in_series++;
 		}
 
 		// add the series slug to the post series box class
@@ -64,18 +64,18 @@ class Post {
 
 		ob_start();
 
-		$this->series_box_html( array(
-			'series'                => $series,
-			'description'           => $term_description,
-			'posts_in_series'       => $posts_in_series,
-			'post_in_series'        => $post_in_series,
-			'post_series_box_class' => $post_series_box_class,
-		) );
+		$this->series_box_html( [
+									'series'                => $series,
+									'description'           => $term_description,
+									'posts_in_series'       => $posts_in_series,
+									'post_in_series'        => $post_in_series,
+									'post_series_box_class' => $post_series_box_class,
+								] );
 
 		$info_box = ob_get_clean();
 
 		$prepend = apply_filters( 'wp_post_series_prepend_info', true );
-		$append  = apply_filters( 'wp_post_series_append_info', true );
+		$append = apply_filters( 'wp_post_series_append_info', true );
 
 		if ( $prepend ) {
 			$content = $info_box . $content;
@@ -91,7 +91,8 @@ class Post {
 	function series_box_html( $args ) {
 		extract( $args );
 		?>
-		<aside class="<?php echo $post_series_box_class; ?>">
+		<aside
+			class="<?php echo $post_series_box_class; ?>">
 			<p class="post-series-name">
 				<?php
 				if ( apply_filters( 'wp_post_series_enable_archive', false ) ) {
@@ -105,7 +106,8 @@ class Post {
 
 			<?php if ( is_single() && sizeof( $posts_in_series ) > 1 ) : ?>
 
-				<nav class="post-series-nav">
+				<nav
+					class="post-series-nav">
 					<ol>
 						<?php foreach ( $posts_in_series as $key => $post_id ) : ?>
 							<li>
@@ -124,7 +126,8 @@ class Post {
 
 			<?php if ( is_single() ) : ?>
 				<?php if ( $description ) : ?>
-					<div class="post-series-description"><?php echo wpautop( wptexturize( $description ) ); ?></div>
+					<div
+						class="post-series-description"><?php echo wpautop( wptexturize( $description ) ); ?></div>
 				<?php endif; ?>
 
 			<?php endif; ?>
@@ -135,7 +138,7 @@ class Post {
 	/**
 	 * Get a post's series
 	 *
-	 * @param  int $post_id post ID
+	 * @param int $post_id post ID
 	 *
 	 * @return object the term object
 	 */
@@ -154,7 +157,7 @@ class Post {
 	/**
 	 * Get the ID of a post's series
 	 *
-	 * @param  int $post_id post ID
+	 * @param int $post_id post ID
 	 *
 	 * @return int series ID
 	 */

--- a/src/PostSeries.php
+++ b/src/PostSeries.php
@@ -126,9 +126,9 @@ class PostSeries {
 	 * @return \WP_Post|null
 	 */
 	public static function get_intro_page( $post_series ) {
-		$term_id = is_a( $post_series, \WP_Term::class ) ? $post_series->term_id : $post_series;
+		$post_series_id = is_a( $post_series, \WP_Term::class ) ? $post_series->term_id : $post_series;
 
-		$intro_page_id = self::get_intro_page_id();
+		$intro_page_id = self::get_intro_page_id( $post_series_id );
 
 		if ( empty( $intro_page_id ) ) {
 			return null;

--- a/src/PostSeries.php
+++ b/src/PostSeries.php
@@ -6,17 +6,17 @@ use DeliciousBrains\WPPostSeries\Admin\PostSeriesMeta;
 
 class PostSeries {
 
-    const TEXT_DOMAIN = 'delicious_brains';
+	const TEXT_DOMAIN = 'delicious_brains';
 
-    const TAXONOMY_NAME = 'post_series';
+	const TAXONOMY_NAME = 'post_series';
 
 	public function init() {
-		$post      = new Post();
+		$post = new Post();
 		$adminPost = new Admin\Post( $post );
 		( new Admin\Taxonomy( $adminPost ) )->init();
 		$adminPost->init();
 		$post->init();
-        $postSeriesMeta = new Admin\PostSeriesMeta();
+		$postSeriesMeta = new Admin\PostSeriesMeta();
 	}
 
 	/**
@@ -25,27 +25,27 @@ class PostSeries {
 	 * @return \WP_Query
 	 */
 	public static function get_all() {
-		$terms = get_terms( array(
-                                'taxonomy' => PostSeries::TAXONOMY_NAME,
-                                'fields'   => 'ids',
-		) );
+		$terms = get_terms( [
+								'taxonomy' => PostSeries::TAXONOMY_NAME,
+								'fields'   => 'ids',
+							] );
 
-		$args = array(
-			'post_per_page' => - 1,
+		$args = [
+			'post_per_page' => -1,
 			'post_type'     => 'post',
 			'post_status'   => 'publish',
-			'tax_query'     => array(
-				array(
-                    'taxonomy' => PostSeries::TAXONOMY_NAME,
-                    'terms'    => $terms,
-				),
-			),
-		);
+			'tax_query'     => [
+				[
+					'taxonomy' => PostSeries::TAXONOMY_NAME,
+					'terms'    => $terms,
+				],
+			],
+		];
 
-		add_filter( 'posts_clauses', array( self::class, 'filter_posts_clauses' ) );
+		add_filter( 'posts_clauses', [ self::class, 'filter_posts_clauses' ] );
 		$query = new \WP_Query();
 		$query->query( $args );
-		remove_filter( 'posts_clauses', array( self::class, 'filter_posts_clauses' ) );
+		remove_filter( 'posts_clauses', [ self::class, 'filter_posts_clauses' ] );
 
 		$query->posts = array_map( function ( $post ) {
 			$post->post_title = $post->name;
@@ -67,11 +67,11 @@ class PostSeries {
 	public static function filter_posts_clauses( $clauses ) {
 		global $wpdb;
 
-		$clauses['fields']  .= ", {$wpdb->terms}.*";
-		$clauses['join']    .= " LEFT JOIN {$wpdb->term_taxonomy} ON ({$wpdb->term_relationships}.term_taxonomy_id = {$wpdb->term_taxonomy}.term_taxonomy_id)";
-		$clauses['join']    .= " LEFT JOIN {$wpdb->terms} ON ({$wpdb->term_taxonomy}.term_id = {$wpdb->terms}.term_id)";
-		$clauses['groupby'] = "{$wpdb->term_relationships}.term_taxonomy_id";
-		$clauses['orderby'] = "{$wpdb->terms}.term_order";
+		$clauses[ 'fields' ] .= ", {$wpdb->terms}.*";
+		$clauses[ 'join' ] .= " LEFT JOIN {$wpdb->term_taxonomy} ON ({$wpdb->term_relationships}.term_taxonomy_id = {$wpdb->term_taxonomy}.term_taxonomy_id)";
+		$clauses[ 'join' ] .= " LEFT JOIN {$wpdb->terms} ON ({$wpdb->term_taxonomy}.term_id = {$wpdb->terms}.term_id)";
+		$clauses[ 'groupby' ] = "{$wpdb->term_relationships}.term_taxonomy_id";
+		$clauses[ 'orderby' ] = "{$wpdb->terms}.term_order";
 
 		return $clauses;
 	}
@@ -79,74 +79,74 @@ class PostSeries {
 	/**
 	 * Get all posts from a post series.
 	 *
-	 * @param int   $term_id Term ID.
+	 * @param int $term_id Term ID.
 	 * @param array $args Query arguments.
 	 * @return int[]|\WP_Post[]
 	 */
-	public static function get_all_by_term( $term_id, $args = array() ) {
-		$defaults = array(
+	public static function get_all_by_term( $term_id, $args = [] ) {
+		$defaults = [
 			'post_type'      => 'post',
 			'posts_per_page' => -1,
 			'fields'         => 'ids',
 			'no_found_rows'  => true,
 			'orderby'        => 'date',
 			'order'          => 'asc',
-			'tax_query'      => array(
-				array(
-                    'taxonomy' => PostSeries::TAXONOMY_NAME,
-                    'field'    => 'id',
-                    'terms'    => $term_id,
-				),
-			),
-		);
+			'tax_query'      => [
+				[
+					'taxonomy' => PostSeries::TAXONOMY_NAME,
+					'field'    => 'id',
+					'terms'    => $term_id,
+				],
+			],
+		];
 
 		return get_posts( wp_parse_args( $args, $defaults ) );
 	}
 
-    /**
-     * Get the ID of the introduction page associated with a post series.
-     *
-     * Returns the ID if there is a page, or an empty string for any other condition.
-     *
-     * @param int|\WP_Term $post_series The post series to get the intro page ID for - can be a WP_Term object or an ID
-     * @return string
-     */
-    public static function get_intro_page_id( $post_series ) {
-        $term_id = is_a( $post_series, \WP_Term::class ) ? $post_series->term_id : $post_series;
+	/**
+	 * Get the ID of the introduction page associated with a post series.
+	 *
+	 * Returns the ID if there is a page, or an empty string for any other condition.
+	 *
+	 * @param int|\WP_Term $post_series The post series to get the intro page ID for - can be a WP_Term object or an ID
+	 * @return string
+	 */
+	public static function get_intro_page_id( $post_series ) {
+		$term_id = is_a( $post_series, \WP_Term::class ) ? $post_series->term_id : $post_series;
 
-        $page_id = get_term_meta( $term_id, PostSeriesMeta::INTRO_PAGE_ID_META_KEY, true );
+		$page_id = get_term_meta( $term_id, PostSeriesMeta::INTRO_PAGE_ID_META_KEY, true );
 
-        return ( false === $page_id ) ? '' : $page_id;
-    }
+		return ( false === $page_id ) ? '' : $page_id;
+	}
 
-    /**
-     * Get the WP_Post object of the introduction page associated with a post series.
-     *
-     * @param int|\WP_Term $post_series The post series to get the intro page for - can be a WP_Term object or an ID
-     * @return \WP_Post|null
-     */
-    public static function get_intro_page( $post_series ) {
-        $term_id = is_a( $post_series, \WP_Term::class ) ? $post_series->term_id : $post_series;
+	/**
+	 * Get the WP_Post object of the introduction page associated with a post series.
+	 *
+	 * @param int|\WP_Term $post_series The post series to get the intro page for - can be a WP_Term object or an ID
+	 * @return \WP_Post|null
+	 */
+	public static function get_intro_page( $post_series ) {
+		$term_id = is_a( $post_series, \WP_Term::class ) ? $post_series->term_id : $post_series;
 
-        $intro_page_id = self::get_intro_page_id();
+		$intro_page_id = self::get_intro_page_id();
 
-        if ( empty( $intro_page_id ) ) {
-            return null;
-        }
+		if ( empty( $intro_page_id ) ) {
+			return null;
+		}
 
-        return get_post( $intro_page_id );
-    }
+		return get_post( $intro_page_id );
+	}
 
-    /**
-     * Set the ID of the introduction page associated with a post series.
-     *
-     * @param int|\WP_Term $post_series    The post series to set the intro page ID for - can be a WP_Term object or an ID
-     * @param int          $intro_page_id  The page ID value to set
-     * @return void
-     */
-    public static function set_intro_page_id( $post_series, $intro_page_id ) {
-        $term_id = is_a( $post_series, \WP_Term::class ) ? $post_series->term_id : $post_series;
+	/**
+	 * Set the ID of the introduction page associated with a post series.
+	 *
+	 * @param int|\WP_Term $post_series The post series to set the intro page ID for - can be a WP_Term object or an ID
+	 * @param int $intro_page_id The page ID value to set
+	 * @return void
+	 */
+	public static function set_intro_page_id( $post_series, $intro_page_id ) {
+		$term_id = is_a( $post_series, \WP_Term::class ) ? $post_series->term_id : $post_series;
 
-        update_term_meta( $term_id, PostSeriesMeta::INTRO_PAGE_ID_META_KEY, $intro_page_id );
-    }
+		update_term_meta( $term_id, PostSeriesMeta::INTRO_PAGE_ID_META_KEY, $intro_page_id );
+	}
 }

--- a/src/PostSeries.php
+++ b/src/PostSeries.php
@@ -2,7 +2,11 @@
 
 namespace DeliciousBrains\WPPostSeries;
 
+use DeliciousBrains\WPPostSeries\Admin\PostSeriesMeta;
+
 class PostSeries {
+
+    const TEXT_DOMAIN = 'delicious_brains';
 
 	public function init() {
 		$post      = new Post();
@@ -10,6 +14,7 @@ class PostSeries {
 		( new Admin\Taxonomy( $adminPost ) )->init();
 		$adminPost->init();
 		$post->init();
+        $postSeriesMeta = new Admin\PostSeriesMeta();
 	}
 
 	/**
@@ -74,7 +79,7 @@ class PostSeries {
 	 *
 	 * @param int   $term_id Term ID.
 	 * @param array $args Query arguments.
-	 * @return int[]|WP_Post[]
+	 * @return int[]|\WP_Post[]
 	 */
 	public static function get_all_by_term( $term_id, $args = array() ) {
 		$defaults = array(
@@ -95,4 +100,51 @@ class PostSeries {
 
 		return get_posts( wp_parse_args( $args, $defaults ) );
 	}
+
+    /**
+     * Get the ID of the introduction page associated with a post series.
+     *
+     * Returns the ID if there is a page, or an empty string for any other condition.
+     *
+     * @param int|\WP_Term $post_series The post series to get the intro page ID for - can be a WP_Term object or an ID
+     * @return string
+     */
+    public static function get_intro_page_id( $post_series ) {
+        $term_id = is_a( $post_series, \WP_Term::class ) ? $post_series->term_id : $post_series;
+
+        $page_id = get_term_meta( $term_id, PostSeriesMeta::INTRO_PAGE_ID_META_KEY, true );
+
+        return ( false === $page_id ) ? '' : $page_id;
+    }
+
+    /**
+     * Get the WP_Post object of the introduction page associated with a post series.
+     *
+     * @param int|\WP_Term $post_series The post series to get the intro page for - can be a WP_Term object or an ID
+     * @return \WP_Post|null
+     */
+    public static function get_intro_page( $post_series ) {
+        $term_id = is_a( $post_series, \WP_Term::class ) ? $post_series->term_id : $post_series;
+
+        $intro_page_id = self::get_intro_page_id();
+
+        if ( empty( $intro_page_id ) ) {
+            return null;
+        }
+
+        return get_post( $intro_page_id );
+    }
+
+    /**
+     * Set the ID of the introduction page associated with a post series.
+     *
+     * @param int|\WP_Term $post_series    The post series to set the intro page ID for - can be a WP_Term object or an ID
+     * @param int          $intro_page_id  The page ID value to set
+     * @return void
+     */
+    public static function set_intro_page_id( $post_series, $intro_page_id ) {
+        $term_id = is_a( $post_series, \WP_Term::class ) ? $post_series->term_id : $post_series;
+
+        update_term_meta( $term_id, PostSeriesMeta::INTRO_PAGE_ID_META_KEY, $intro_page_id );
+    }
 }

--- a/src/PostSeries.php
+++ b/src/PostSeries.php
@@ -8,6 +8,8 @@ class PostSeries {
 
     const TEXT_DOMAIN = 'delicious_brains';
 
+    const TAXONOMY_NAME = 'post_series';
+
 	public function init() {
 		$post      = new Post();
 		$adminPost = new Admin\Post( $post );
@@ -24,8 +26,8 @@ class PostSeries {
 	 */
 	public static function get_all() {
 		$terms = get_terms( array(
-			'taxonomy' => 'post_series',
-			'fields'   => 'ids',
+                                'taxonomy' => PostSeries::TAXONOMY_NAME,
+                                'fields'   => 'ids',
 		) );
 
 		$args = array(
@@ -34,8 +36,8 @@ class PostSeries {
 			'post_status'   => 'publish',
 			'tax_query'     => array(
 				array(
-					'taxonomy' => 'post_series',
-					'terms'    => $terms,
+                    'taxonomy' => PostSeries::TAXONOMY_NAME,
+                    'terms'    => $terms,
 				),
 			),
 		);
@@ -91,9 +93,9 @@ class PostSeries {
 			'order'          => 'asc',
 			'tax_query'      => array(
 				array(
-					'taxonomy' => 'post_series',
-					'field'    => 'id',
-					'terms'    => $term_id,
+                    'taxonomy' => PostSeries::TAXONOMY_NAME,
+                    'field'    => 'id',
+                    'terms'    => $term_id,
 				),
 			),
 		);


### PR DESCRIPTION
This would have been WAY easier with ACF, of course, but I didn't want to add it as a dependency.

This PR adds a custom term meta for choosing an introduction post for a post series.

Currently I assume that the page list isn't too long, so we use a standard `select` rather than anything fancy and searchable.

This introduces two useful static methods:
 - `PostSeries::get_intro_page_id()`
 - `PostSeries::get_intro_page()`